### PR TITLE
publish image to docker instead of local build

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ ansible-playbook setup-via-ansible.yml  //may take 3-4 mins.
 PLAY RECAP *************************************************************************************************************************************************************************************************
 localhost                  : ok=7    changed=6    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
 
+
+//Note: Docker image already published - docker pull registry.hub.docker.com/kaushik100/shield:1.3.0
 ```
 #### Verification and try it out!
 1. Ensure all pods are "running" for atleast 2 mins (just to ensure no crashloops). It may take 2-3 mins. 

--- a/k8s_deployment_specs/shield.yml
+++ b/k8s_deployment_specs/shield.yml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: shield
-        image: shield:1.3.0
+        image: registry.hub.docker.com/kaushik100/shield:1.3.0
         ports:
         - containerPort: 8080
         - containerPort: 8081

--- a/kind-cluster-config.yml
+++ b/kind-cluster-config.yml
@@ -6,9 +6,11 @@ nodes:
   extraPortMappings:
   - containerPort: 30007
     hostPort: 8080
+    listenAddress: 0.0.0.0
   - containerPort: 443
     hostPort: 8443
     protocol: TCP
   - containerPort: 30008
     hostPort: 8081
+    listenAddress: 0.0.0.0
 - role: worker

--- a/setup-via-ansible.yml
+++ b/setup-via-ansible.yml
@@ -4,8 +4,14 @@
     - name: Create a kind cluster
       shell: "kind create cluster --config kind-cluster-config.yml --name kind"
 
-    - name: Build the docker image for Shield
-      shell: "docker build . -t shield:1.3.0"
+    - name: Get the docker image
+      shell: "docker pull kaushik100/shield:1.3.0"
+
+    - name: Retag the image
+      shell: "docker tag kaushik100/shield:1.3.0 shield:1.3.0"
+
+#    - name: Build the docker image for Shield
+#      shell: "docker build . -t shield:1.3.0"
 
     - name: Load docker image to kind cluster
       shell: "kind load docker-image shield:1.3.0 --name kind"

--- a/setup-via-ansible.yml
+++ b/setup-via-ansible.yml
@@ -5,16 +5,13 @@
       shell: "kind create cluster --config kind-cluster-config.yml --name kind"
 
     - name: Get the docker image
-      shell: "docker pull kaushik100/shield:1.3.0"
-
-    - name: Retag the image
-      shell: "docker tag kaushik100/shield:1.3.0 shield:1.3.0"
+      shell: "docker pull registry.hub.docker.com/kaushik100/shield:1.3.0"
 
 #    - name: Build the docker image for Shield
-#      shell: "docker build . -t shield:1.3.0"
+#      shell: "docker build . -t registry.hub.docker.com/kaushik100/shield:1.3.0"
 
     - name: Load docker image to kind cluster
-      shell: "kind load docker-image shield:1.3.0 --name kind"
+      shell: "kind load docker-image registry.hub.docker.com/kaushik100/shield:1.3.0 --name kind"
 
     - name: Add bitnami repo
       shell: "helm repo add bitnami https://charts.bitnami.com/bitnami"


### PR DESCRIPTION
Publish an image to docker & reuse that for deployment instead of `docker build ...`. `docker build` also works, but will require all the packages locally. 